### PR TITLE
Fix usage of NPROC in Dockerfiles

### DIFF
--- a/abseil_cpp/Dockerfile
+++ b/abseil_cpp/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR $HOME/abseil-cpp
 RUN nice cmake -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
   -DCMAKE_INSTALL_PREFIX:PATH=$HOME/install . && \
-  nice make all install -j$NPROC
+  nice make all install -j${NPROC:-3}

--- a/aws_sdk/Dockerfile
+++ b/aws_sdk/Dockerfile
@@ -12,6 +12,8 @@ FROM $openssl_IMAGE_TAG as build-openssl
 FROM $curl_IMAGE_TAG as build-curl
 FROM $base_IMAGE_TAG
 
+ARG NPROC
+
 WORKDIR $HOME
 
 COPY aws-sdk-cpp aws-sdk-cpp
@@ -34,5 +36,5 @@ RUN cmake \
   -DCMAKE_INSTALL_PREFIX:PATH=$HOME/install \
   $HOME/aws-sdk-cpp
 
-RUN nice make -j$NPROC
+RUN nice make -j${NPROC:-3}
 RUN nice make install

--- a/bcc/Dockerfile
+++ b/bcc/Dockerfile
@@ -7,7 +7,7 @@ ARG base_IMAGE_TAG
 FROM $base_IMAGE_TAG
 
 ARG CMAKE_BUILD_TYPE
-ARG RESTRICTED_NPROC=1
+ARG RESTRICTED_NPROC
 
 RUN apt-get install --no-install-recommends -y zip
 
@@ -21,4 +21,4 @@ RUN cmake \
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
   -DENABLE_LLVM_SHARED=OFF \
   $HOME/bcc
-RUN nice ninja -j $RESTRICTED_NPROC && ninja -j $RESTRICTED_NPROC install
+RUN nice ninja -j ${RESTRICTED_NPROC:-1} && ninja -j ${RESTRICTED_NPROC:-1} install

--- a/cpp_misc/Dockerfile
+++ b/cpp_misc/Dockerfile
@@ -42,7 +42,7 @@ RUN PATH=$PATH:$HOME/build/breakpad/depot_tools fetch breakpad
 
 # configure breakpad to avoid using getrandom() to reduce GLIBC_2.25 dependency
 RUN CXXFLAGS="-Wno-narrowing" src/configure ac_cv_func_getrandom=no --prefix=$HOME/install
-RUN CFLAGS=`echo ${BUILD_CFLAGS} | sed 's/\\\\ / /g'`; nice make -j$NPROC && nice make install
+RUN CFLAGS=`echo ${BUILD_CFLAGS} | sed 's/\\\\ / /g'`; nice make -j${NPROC:-3} && nice make install
 
 # args
 WORKDIR $HOME
@@ -59,7 +59,7 @@ RUN cmake \
   -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
   -DJSON_BuildTests=OFF \
   .
-RUN cmake --build . --target install -j $NPROC --config $CMAKE_BUILD_TYPE
+RUN nice cmake --build . --target install -j ${NPROC:-3} --config $CMAKE_BUILD_TYPE
 
 # spdlog
 WORKDIR $HOME
@@ -72,7 +72,7 @@ RUN cmake \
   -DSPDLOG_BUILD_EXAMPLES=OFF \
   -DSPDLOG_BUILD_TESTING=OFF \
   .
-RUN cmake --build . --target install -j $NPROC --config $CMAKE_BUILD_TYPE
+RUN nice cmake --build . --target install -j ${NPROC:-3} --config $CMAKE_BUILD_TYPE
 
 # ccan
 WORKDIR $HOME
@@ -89,7 +89,7 @@ RUN cmake \
   -DBUILD_GMOCK=ON \
   -DINSTALL_GTEST=OFF \
   .
-RUN cmake --build . -j $NPROC --config $CMAKE_BUILD_TYPE
+RUN nice cmake --build . -j ${NPROC:-3} --config $CMAKE_BUILD_TYPE
 RUN cp lib/*.a $HOME/install/lib
 RUN cp -R googletest/include/gtest $HOME/install/include
 RUN cp -R googlemock/include/gmock $HOME/install/include

--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -11,6 +11,7 @@ FROM $base_IMAGE_TAG
 
 ARG CMAKE_BUILD_TYPE
 ARG CURL_LIBRARY
+ARG NPROC
 
 ######################
 # openssl dependency #
@@ -47,7 +48,7 @@ RUN nice cmake \
 	-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 	-DCMAKE_DEBUG_POSTFIX="" \
 	$HOME/curl
-RUN nice make -j$NPROC && nice make -j$NPROC install
+RUN nice make -j${NPROC:-3} && nice make -j${NPROC:-3} install
 
 ##########
 # curlpp #
@@ -61,4 +62,4 @@ RUN nice cmake \
 	-DCMAKE_PREFIX_PATH:PATH=$HOME/install \
 	-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 	$HOME/curlpp
-RUN nice make -j$NPROC && nice make -j$NPROC install
+RUN nice make -j${NPROC:-3} && nice make -j${NPROC:-3} install

--- a/gcp_cpp/Dockerfile
+++ b/gcp_cpp/Dockerfile
@@ -42,8 +42,8 @@ RUN nice cmake \
 	-DCMAKE_C_FLAGS="-fPIC" \
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 	$HOME/google-cloud-cpp-common
-RUN nice make -j$NPROC
-RUN nice make -j$NPROC install
+RUN nice make -j${NPROC:-3}
+RUN nice make -j${NPROC:-3} install
 
 ####################
 # google-cloud-cpp #
@@ -67,5 +67,5 @@ RUN nice cmake \
 	-DCMAKE_C_FLAGS="-fPIC" \
   -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
 	$HOME/google-cloud-cpp
-RUN nice make -j$NPROC
-#RUN nice make -j$NPROC install
+RUN nice make -j${NPROC:-3}
+#RUN nice make -j${NPROC:-3} install

--- a/grpc_cpp/Dockerfile
+++ b/grpc_cpp/Dockerfile
@@ -13,6 +13,9 @@ FROM $openssl_IMAGE_TAG as build-openssl
 FROM $abseil_cpp_IMAGE_TAG as build-abseil
 FROM $base_IMAGE_TAG
 
+# need to redeclare after FROM
+ARG NPROC
+
 WORKDIR $HOME
 
 COPY grpc grpc
@@ -41,4 +44,4 @@ RUN cmake \
   -DCMAKE_INSTALL_PREFIX="$HOME/install" \
   $HOME/grpc
 
-RUN make -j$NPROC install
+RUN nice make -j${NPROC:-3} install

--- a/libmaxminddb/Dockerfile
+++ b/libmaxminddb/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR $HOME/libmaxminddb
 RUN ./bootstrap
 RUN ./configure ${CONFIGURE_ENABLE_DEBUG} --prefix=$HOME/install \
     --enable-static
-RUN nice make -j$NPROC && make install
+RUN nice make -j${NPROC:-3} && make install

--- a/libuv/Dockerfile
+++ b/libuv/Dockerfile
@@ -16,4 +16,4 @@ WORKDIR $HOME/libuv
 RUN ./autogen.sh
 WORKDIR $HOME/build/libuv
 RUN $HOME/libuv/configure --prefix=$HOME/install
-RUN CFLAGS=`echo ${BUILD_CFLAGS} | sed 's/\\\\ / /g'`; nice make -j$NPROC && make install
+RUN CFLAGS=`echo ${BUILD_CFLAGS} | sed 's/\\\\ / /g'`; nice make -j${NPROC:-3} && make install

--- a/openssl/Dockerfile
+++ b/openssl/Dockerfile
@@ -28,5 +28,5 @@ RUN ./Configure linux-x86_64 \
 	no-mdc2 no-ocb no-rc2 no-rmd160 no-scrypt no-whirlpool
 # would also want 	--api=1.1.0  but AWS CLI is built on 1.0.2 API
 # no-ui, no-sock conflict with curl
-RUN nice make -j$NPROC
+RUN nice make -j${NPROC:-3}
 RUN nice make install


### PR DESCRIPTION
Some Dockerfiles did not correctly inherit the NPROC configuration from the build script. This resulted in some of the containers spawning high numbers of compiler processes, requiring extremely large quantities of RAM. For example, grpc failed to build on a machine with 8 vCPUs and 64 GB of RAM.

This PR is a fix pass over all Dockerfiles in the repo.

* Ensure `ARG NPROC` after the last `FROM`
* Provide default value in case NPROC is not provided, e.g., `${NPROC:-3}`
* add `nice` on large make calls where missing, in hopes of keeping the host system responsive during large compilations