### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -37,7 +37,8 @@ env:
 jobs:
   build-and-release:
     name: Build and release
-    runs-on: ubuntu-20.04
+    runs-on:
+      labels: otel-linux-latest-2-cores
     steps:
       - name: Log-in to container registry
         run: |

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -68,8 +68,8 @@ jobs:
           echo "git_short_hash = ${git_short_hash}"
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y cmake build-essential
+          sudo apt-get update
+          sudo apt-get install -y cmake build-essential
       - name: Build build-env container
         run: |
           cd $GITHUB_WORKSPACE/src


### PR DESCRIPTION
* when testing the build with the act framework, it was possible to run `apt-get` in the builder, but this fails on GH Actions' builder. This PR adds `sudo` to the `apt-get`
* added a selector for Runner to get the large runner configured by @trask 