### PR TITLE
Increase Github Actions runner size

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -38,7 +38,7 @@ jobs:
   build-and-release:
     name: Build and release
     runs-on:
-      labels: otel-linux-latest-2-cores
+      labels: otel-linux-latest-4-cores
     steps:
       - name: Log-in to container registry
         run: |


### PR DESCRIPTION
This increases the amount of storage that the runner has to enable the build to finish.

This follows the increase in https://github.com/open-telemetry/community/issues/2399#issuecomment-2429492643