### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,1 @@
+# Contributing to OpenTelemetry-eBPF Build Tools

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,1 +1,56 @@
-# Contributing to OpenTelemetry-eBPF Build Tools
+ # Contributing to OpenTelemetry-eBPF Build Tools
+
+## Introduction
+
+Welcome to the OpenTelemetry-eBPF Build Tools repository! 🎉
+This repository contains third-party tools and libraries needed to build projects in the `opentelemetry-ebpf` repository.
+
+Building this repository results in a build environment container image that is then used for building artifacts of the main project (see the [Developer Guide](https://github.com/open-telemetry/opentelemetry-network/blob/main/docs/developing.md)).
+
+We value all contributions, whether big or small, and encourage you to join us in improving this project. If you have questions, don’t hesitate to reach out to the OpenTelemetry community—we’re here to help!
+
+### MacOS Prerequisites
+
+To work with this repository on MacOS, you need:
+
+**The [Homebrew](https://brew.sh/) package manager** (Ensure you have it installed)
+[**Docker Desktop**](https://docs.docker.com/desktop/setup/install/mac-install/) (For containerized builds)
+**CMake**: Install using Homebrew
+  ```sh
+  brew install cmake
+  ```
+**Make**: Installed along with developer tools; if Homebrew is working, you should have `make` available.
+
+### Other Platform Prerequisites
+**TBD**
+
+## Local Run/Build
+
+### How to set up and run the project locally
+Check out this repository.
+Run the build script:
+  ```sh
+  ./build.sh
+  ```
+
+## Testing
+How to run the test suite for the repository: **TBD**
+
+## Contribution Guidelines
+This guide outlines best practices and requirements to ensure a smooth and effective contribution process.
+
+### Adhering to Coding Standards
+Follow the project's coding standards outlined in **TBD**.
+Use clear and concise naming conventions for variables, functions, and files.
+Run linters or formatters where applicable to maintain consistent code style.
+
+### Community Standards and Style Guides
+This project adheres to the OpenTelemetry community's standards. Please ensure you:
+Follow the [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
+Align with any specific style guides, such as **TBD**.
+
+## Further Help
+### Where contributors can seek assistance
+Links to communication platforms like Slack or Discord: **TBD**
+
+Thank you for contributing to OpenTelemetry-eBPF Build Tools! 🎉

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -40,10 +40,9 @@ Run the build script:
 Use clear and concise naming conventions for variables, functions, and files.
 
 ### Community Standards and Style Guides
+
 This project adheres to the OpenTelemetry community's standards. Please ensure you:
 
 Follow the [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
-
-Align with any specific style guides, such as **TBD**.
 
 Thank you for contributing to OpenTelemetry-eBPF Build Tools! 🎉

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -21,9 +21,6 @@ To work with this repository on MacOS, you need:
   ```
 **Make**: Installed along with developer tools; if Homebrew is working, you should have `make` available.
 
-### Other Platform Prerequisites
-**TBD**
-
 ## Workflow
 
 1. Fork the repository
@@ -39,18 +36,8 @@ Run the build script:
   ./build.sh
   ```
 
-## Testing
-How to run the test suite for the repository: **TBD**
-
 ## Contribution Guidelines
-This guide outlines best practices and requirements to ensure a smooth and effective contribution process.
-
-### Adhering to Coding Standards
-Follow the project's coding standards outlined in **TBD**.
-
 Use clear and concise naming conventions for variables, functions, and files.
-
-Run linters or formatters where applicable to maintain consistent code style.
 
 ### Community Standards and Style Guides
 This project adheres to the OpenTelemetry community's standards. Please ensure you:
@@ -58,9 +45,5 @@ This project adheres to the OpenTelemetry community's standards. Please ensure y
 Follow the [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
 
 Align with any specific style guides, such as **TBD**.
-
-## Further Help
-### Where contributors can seek assistance
-Links to communication platforms like Slack or Discord: **TBD**
 
 Thank you for contributing to OpenTelemetry-eBPF Build Tools! 🎉

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -41,12 +41,16 @@ This guide outlines best practices and requirements to ensure a smooth and effec
 
 ### Adhering to Coding Standards
 Follow the project's coding standards outlined in **TBD**.
+
 Use clear and concise naming conventions for variables, functions, and files.
+
 Run linters or formatters where applicable to maintain consistent code style.
 
 ### Community Standards and Style Guides
 This project adheres to the OpenTelemetry community's standards. Please ensure you:
+
 Follow the [Code of Conduct](https://github.com/open-telemetry/community/blob/main/code-of-conduct.md).
+
 Align with any specific style guides, such as **TBD**.
 
 ## Further Help

--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -24,6 +24,12 @@ To work with this repository on MacOS, you need:
 ### Other Platform Prerequisites
 **TBD**
 
+## Workflow
+
+1. Fork the repository
+2. Work on own branch
+3. Create a PR to fix an issue
+
 ## Local Run/Build
 
 ### How to set up and run the project locally


### PR DESCRIPTION
### part of [Add Contributing guide to repos](https://github.com/open-telemetry/sig-contributor-experience/issues/31#top) #31

This pull request standardizes the setup guide for the opentelemetry-network-build-tools repository using the proposed template

### Next Steps:
Contributors and maintainers are encouraged to help fill in the "TBD" sections with accurate and specific details for this repository. Feedback and suggestions are highly welcomed!

This update aims to make it easier for contributors to get started with the project and follow best practices while contributing.

Please review and let me know if you have any suggestions or feedback.

cc @bjandras @yonch 