### PR TITLE
Change runner to use ubuntu-latest

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -37,8 +37,7 @@ env:
 jobs:
   build-and-release:
     name: Build and release
-    runs-on:
-      labels: otel-linux-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Log-in to container registry
         run: |


### PR DESCRIPTION
the [standard runner](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) for linux has the same cores and memory, so we'd like to remove the `otel-linux-latest-4-cores` runner at the org level (see https://github.com/open-telemetry/community/issues/2564), or do you specifically need the larger disk space that `otel-linux-latest-4-cores` has compared to `ubuntu-latest`?