### PR TITLE
Arm64 support for the build container (#13)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -86,7 +86,10 @@ RUN apt-get -y install $PKG_BCC
 
 # Recent version of Go
 WORKDIR /usr/local
-RUN curl -L "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz
+RUN case $(uname -m) in \
+     x86_64) curl -L "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -xz ;; \
+     aarch64) curl -L "https://go.dev/dl/go${GO_VERSION}.linux-arm64.tar.gz" | tar -xz  ;; \
+   esac
 # recommended: add PATH=$PATH:/usr/local/go/bin to ~/.bashrc
 
 # upgrade packages to latest

--- a/cpp_misc/Dockerfile
+++ b/cpp_misc/Dockerfile
@@ -40,6 +40,9 @@ WORKDIR $HOME/build/breakpad
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 RUN PATH=$PATH:$HOME/build/breakpad/depot_tools fetch breakpad
 
+# Switch to a version before the c++20 change that isn't supported in debian bullseye
+RUN cd src && git checkout 2c73630 && cd ..
+
 # configure breakpad to avoid using getrandom() to reduce GLIBC_2.25 dependency
 RUN CXXFLAGS="-Wno-narrowing" src/configure ac_cv_func_getrandom=no --prefix=$HOME/install
 RUN CFLAGS=`echo ${BUILD_CFLAGS} | sed 's/\\\\ / /g'`; nice make -j${NPROC:-3} && nice make install

--- a/final/Dockerfile
+++ b/final/Dockerfile
@@ -66,8 +66,15 @@ ARG PKG_EXTRA_PACKAGES="openjdk-${BENV_JAVA_VERSION}-jdk-headless google-cloud-s
 RUN apt-get -y update && apt-get install -y --no-install-recommends $PKG_EXTRA_PACKAGES
 
 ## java version required by render framework parser
-RUN update-alternatives --set java /usr/lib/jvm/java-${BENV_JAVA_VERSION}-openjdk-amd64/bin/java
-RUN update-alternatives --set javac /usr/lib/jvm/java-${BENV_JAVA_VERSION}-openjdk-amd64/bin/javac
+RUN case $(uname -m) in \
+      x86_64) update-alternatives --set java /usr/lib/jvm/java-${BENV_JAVA_VERSION}-openjdk-amd64/bin/java && \
+              update-alternatives --set javac /usr/lib/jvm/java-${BENV_JAVA_VERSION}-openjdk-amd64/bin/javac \
+              ;; \
+      aarch64) update-alternatives --set java /usr/lib/jvm/java-${BENV_JAVA_VERSION}-openjdk-arm64/bin/java  && \
+              update-alternatives --set javac /usr/lib/jvm/java-${BENV_JAVA_VERSION}-openjdk-arm64/bin/javac \
+              ;; \
+    esac
+
 
 # gradle
 RUN wget https://services.gradle.org/distributions/gradle-7.3.3-bin.zip -O /usr/local/lib/gradle.zip

--- a/openssl/Dockerfile
+++ b/openssl/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR $HOME/openssl
 # remove getentropy() from crypto/rand/rand_unix.c to avoid dependency on GLIBC_2.25
 RUN cat crypto/rand/rand_unix.c | perl -pe 'BEGIN{undef $/;} s/extern int getentropy.*?#  endif/\n#  endif/smg' > /tmp/rand_unix.c && cp /tmp/rand_unix.c crypto/rand
 
-RUN ./Configure linux-x86_64 \
+RUN ./Configure linux-$(uname -m) \
 	--prefix=$HOME/install/openssl \
 	--openssldir=$HOME/install/openssl \
 	${CONFIGURE_RELEASE_DEBUG} \


### PR DESCRIPTION
Switch to the breakpad version before breakpad started requiring a c++20 identifying compiler and add support to the build container to build for arm64 